### PR TITLE
added po_url_test and check for live_po

### DIFF
--- a/ps_utils/app/__init__.py
+++ b/ps_utils/app/__init__.py
@@ -50,6 +50,15 @@ if 'product_urlV2' not in check:
             e = repr(e)
         logging.error('Database not updated. See app.__init__. Error: {}'.format(e))
         exit(1)
+if 'po_url_test' not in check:
+    try:
+        sql = DDL('ALTER TABLE company ADD COLUMN po_url_test VARCHAR(255) AFTER po_url')
+        db.engine.execute(sql)
+        sql = DDL('ALTER TABLE company ADD COLUMN po_wsdl_test VARCHAR(255) AFTER po_wsdl')
+        db.engine.execute(sql)
+    except:
+        logging.error('Database not updated. See app.__init__')
+        exit(1)
 
 appbuilder = AppBuilder(app, db.session)
 csrf = CSRFProtect(app)

--- a/ps_utils/app/models.py
+++ b/ps_utils/app/models.py
@@ -26,6 +26,8 @@ class Company(Model, AuditMixin):
     media_version =  Column(String(564), default='1.0.0')
     order_url =  Column(String(255), nullable=True)
     order_wsdl =  Column(String(255), nullable=True)
+    po_url_test =  Column(String(255), nullable=True)
+    po_wsdl_test =  Column(String(255), nullable=True)
     order_version =  Column(String(564), default='1.0.0')
     po_url =  Column(String(255), nullable=True)
     po_wsdl =  Column(String(255), nullable=True)

--- a/ps_utils/app/templates/purchaseOrder/instructions.html
+++ b/ps_utils/app/templates/purchaseOrder/instructions.html
@@ -11,17 +11,19 @@
         <h4 class="panel-title">Instructions for submitting a PO</h4>
     </div>
     <div class="well">
+        <p style="text-align: center; font-weight: bold;">To submit a production PO for a company, the company's live_po field must be set to 1.</p>
         <p style="text-align: center; font-weight: bold; color: red;">
             When testing...Make sure that you create a companyID that is either:
         </p>
         <p style="text-align: center; font-weight: bold;">
-            Hitting '/jsonpo/receiveTest/' for it's po_url
+            Hitting '<i>scheme://thisdomain</i>/jsonpo/receiveTest/' for it's po_url
         </p>
         <p style="text-align: center; font-weight: bold; color: red;">
             OR
         </p>
         <p style="text-align: center; font-weight: bold;">
-            The po_url and po_wsdl of the requested companyID are pointing to the company test site!
+            The environment variable ENVIRONMENT=1 is commented out or set to 0 and <br/>
+            The po_url_test and po_wsdl_test of the requested companyID are pointing to the company test site!
         </p>
     </div>
     <div>

--- a/ps_utils/app/utilities.py
+++ b/ps_utils/app/utilities.py
@@ -215,6 +215,15 @@ class Utilities(BaseView):
                         c.po_url = row['URL']
                         c.po_wsdl = good_url
                         c.po_version = service_version
+                        # add po test url if available
+                        try:
+                            wsdl_url_test = row['TestURL'].strip() + "?wsdl"
+                            good_url_test = try_url(row['TestURL'].strip(), wsdl_url_test, code, service_version)
+                            if good_url_test:
+                                c.po_url_test = row['TestURL']
+                                c.po_wsdl_test = good_url_test
+                        except:
+                            pass
 
             #save working url endpoints into db
             if has_url:

--- a/start.sh
+++ b/start.sh
@@ -23,5 +23,5 @@ else
 
     # gunicorn
     echo "connections: $GUWORKERS_CONNECTIONS workers: $GUWORKERS"
-    gunicorn --name 'Gunicorn App Gevent'  --bind 0.0.0.0:9000 app:app -k gevent --worker-connections $GUWORKERS_CONNECTIONS --workers $GUWORKERS --log-file /dev/null
+    gunicorn --name 'Gunicorn App Gevent' --chdir /app  --bind 127.0.0.1:9000 app:app -k gevent --worker-connections $GUWORKERS_CONNECTIONS --workers $GUWORKERS --log-file /dev/null
 fi


### PR DESCRIPTION
This can be a breaking change if the live_po is not set to 1 for customers you are processing production PO's with.  This is an added protection against sending POs accidentally.  The other changes also help with this issue. The POs now have a po_url_test and po_wsdl_test field for the company and code uses these fields when the ENVIRONMENT=0 or commented out so that it is not running production.
The utility also now looks for these test urls to auto populate.